### PR TITLE
CPS-14: Make table indexed first before adding to available dataset in the backend

### DIFF
--- a/backend/app/dataset_state.py
+++ b/backend/app/dataset_state.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from sqlalchemy import inspect, text, update
+
+import app.db as app_db
+from app.models import Dataset
+
+
+def ensure_dataset_index_ready_column() -> None:
+    inspector = inspect(app_db.engine)
+    if "datasets" not in inspector.get_table_names():
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("datasets")}
+    if "is_index_ready" in column_names:
+        return
+
+    with app_db.engine.begin() as conn:
+        conn.execute(
+            text(
+                "ALTER TABLE datasets "
+                "ADD COLUMN is_index_ready BOOLEAN NOT NULL DEFAULT FALSE"
+            )
+        )
+
+
+def set_dataset_index_ready(dataset_id: int, is_ready: bool) -> None:
+    with app_db.SessionLocal() as db:
+        db.execute(
+            update(Dataset)
+            .where(Dataset.id == dataset_id)
+            .values(is_index_ready=bool(is_ready))
+        )
+        db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import insert, text, select
 from contextlib import asynccontextmanager
 from app.db import SessionLocal, engine
+from app.dataset_state import (
+    ensure_dataset_index_ready_column,
+    set_dataset_index_ready,
+)
 from app.index_jobs import (
     mark_index_job_error,
     mark_index_job_ready,
@@ -38,6 +42,7 @@ INDEX_WORKER_CONCURRENCY = max(1, int(os.getenv("INDEX_WORKER_CONCURRENCY", "4")
 async def lifespan(app: FastAPI):
     global _index_worker
     Base.metadata.create_all(bind=engine)
+    ensure_dataset_index_ready_column()
     try:
         from app.embeddings import get_model
         get_model()
@@ -250,9 +255,11 @@ def _index_dataset_safe(dataset_id: int, total_rows: int) -> None:
             ),
             expected_total_rows=total_rows,
         )
+        set_dataset_index_ready(dataset_id, True)
         mark_index_job_ready(dataset_id, total_rows)
     except Exception as exc:
         logger.exception("Indexing failed for dataset_id=%s", dataset_id)
+        set_dataset_index_ready(dataset_id, False)
         mark_index_job_error(dataset_id, total_rows, f"Indexing failed: {exc}")
 
 
@@ -269,15 +276,18 @@ def _resume_incomplete_index_jobs() -> None:
 
     with SessionLocal() as db:
         datasets = db.execute(
-            select(Dataset.id, Dataset.row_count)
-            .where(Dataset.row_count > 0)
-            .order_by(Dataset.id.asc())
+            select(Dataset.id, Dataset.row_count, Dataset.is_index_ready).order_by(
+                Dataset.id.asc()
+            )
         ).all()
 
-    for dataset_id_raw, row_count_raw in datasets:
+    for dataset_id_raw, row_count_raw, is_index_ready_raw in datasets:
         dataset_id = int(dataset_id_raw)
         row_count = int(row_count_raw or 0)
+        is_index_ready = bool(is_index_ready_raw)
         if row_count <= 0:
+            if not is_index_ready:
+                set_dataset_index_ready(dataset_id, True)
             continue
 
         try:
@@ -286,8 +296,14 @@ def _resume_incomplete_index_jobs() -> None:
             point_count = None
 
         if point_count is not None and int(point_count) >= row_count:
+            if not is_index_ready:
+                set_dataset_index_ready(dataset_id, True)
+            continue
+        if point_count is None and is_index_ready:
             continue
 
+        if is_index_ready:
+            set_dataset_index_ready(dataset_id, False)
         queue_index_job(dataset_id, row_count)
         _index_worker.enqueue(dataset_id, row_count)
 
@@ -345,6 +361,7 @@ def ingest_table(
             delimiter=detected_delimiter,
             has_header=has_header,
             column_count=len(headers),
+            is_index_ready=False,
         )
         db.add(
             dataset
@@ -383,9 +400,13 @@ def ingest_table(
         )
         db.commit()
 
-    # Start vector indexing after response so uploads don't block on embedding/Qdrant upserts.
-    queue_index_job(dataset_id, row_count)
-    _enqueue_index_job(dataset_id, row_count)
+    if row_count <= 0:
+        set_dataset_index_ready(dataset_id, True)
+        mark_index_job_ready(dataset_id, row_count)
+    else:
+        # Start vector indexing after response so uploads don't block on embedding/Qdrant upserts.
+        queue_index_job(dataset_id, row_count)
+        _enqueue_index_job(dataset_id, row_count)
 
     return {
         "dataset_id": dataset_id,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,15 @@
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, JSON, String, UniqueConstraint, Index
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    UniqueConstraint,
+    false,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -15,6 +26,12 @@ class Dataset(Base):
     has_header = Column(Boolean, nullable=False, default=True)
     row_count = Column(Integer, nullable=False, default=0)
     column_count = Column(Integer, nullable=False, default=0)
+    is_index_ready = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=false(),
+    )
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     columns = relationship("DatasetColumn", back_populates="dataset", cascade="all, delete-orphan")

--- a/backend/app/retrieval.py
+++ b/backend/app/retrieval.py
@@ -309,7 +309,7 @@ def _list_dataset_summaries() -> List[Dict[str, Any]]:
         rows = db.execute(
             text(
                 "SELECT id, name, source_filename, row_count, column_count, created_at "
-                "FROM datasets ORDER BY id DESC"
+                "FROM datasets WHERE is_index_ready = TRUE ORDER BY id DESC"
             )
         ).fetchall()
 

--- a/backend/app/routes_tables.py
+++ b/backend/app/routes_tables.py
@@ -44,13 +44,14 @@ def _delete_collection_safe(dataset_id: int) -> None:
 @router.get(
     "/tables",
     summary="List all datasets",
-    description="Returns all available datasets with their IDs, names, and metadata. Always call this first to discover valid dataset IDs.",
+    description="Returns indexed datasets with their IDs, names, and metadata. Pending uploads are omitted unless include_pending=true.",
 )
-def list_tables():
+def list_tables(include_pending: bool = False):
     with SessionLocal() as db:
-        datasets = (
-            db.execute(select(Dataset).order_by(Dataset.id.desc())).scalars().all()
-        )
+        query = select(Dataset).order_by(Dataset.id.desc())
+        if not include_pending:
+            query = query.where(Dataset.is_index_ready.is_(True))
+        datasets = db.execute(query).scalars().all()
         return [
             {
                 "dataset_id": d.id,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -287,8 +287,15 @@ export async function uploadTable(
   });
 }
 
-export async function listTables(): Promise<TableSummary[]> {
-  const res = await authFetch(`${API_BASE}/tables`, { headers: authHeaders() });
+export async function listTables(options?: {
+  includePending?: boolean;
+}): Promise<TableSummary[]> {
+  const url = new URL(`${API_BASE}/tables`);
+  if (options?.includePending) {
+    url.searchParams.set("include_pending", "true");
+  }
+
+  const res = await authFetch(url.toString(), { headers: authHeaders() });
   if (!res.ok) {
     throw new Error(await res.text());
   }

--- a/frontend/src/pages/TableView.tsx
+++ b/frontend/src/pages/TableView.tsx
@@ -126,7 +126,7 @@ export default function TableView() {
     setDateMenu(null);
 
     let mounted = true;
-    listTables()
+    listTables({ includePending: true })
       .then((tables: TableSummary[]) => {
         if (!mounted) {
           return;

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -340,7 +340,7 @@ export default function Upload() {
   }, []);
 
   const refresh = useCallback(async () => {
-    const nextTables = await listTables();
+    const nextTables = await listTables({ includePending: true });
     setTables(nextTables);
     try {
       await refreshIndexStatuses(nextTables);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def client(test_engine):
 @pytest.fixture(autouse=True)
 def mock_indexing():
     """Prevent Qdrant/embedding calls in all tests by default."""
-    with patch("app.main.index_dataset"):
+    with patch("app.main.index_dataset"), patch("app.main._index_worker", None):
         yield
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,7 @@
 import io
 import json
 import pytest
+from unittest.mock import patch
 from sqlalchemy import text
 
 
@@ -103,6 +104,7 @@ def test_db_dataset_record(client, test_engine):
     assert row is not None
     assert row.row_count == 2
     assert row.column_count == 2
+    assert bool(row.is_index_ready) is True
 
 
 def test_db_columns_stored(client, test_engine):
@@ -120,6 +122,39 @@ def test_db_rows_stored(client, test_engine):
     data = json.loads(rows[0].row_data)
     assert data["name"] == "Alice"
     assert data["age"] == "30"
+
+
+def test_list_tables_returns_ready_datasets_by_default(client):
+    client.post(
+        "/ingest",
+        files=make_csv("name,age\nAlice,30\n"),
+        data={"dataset_name": "ready_table"},
+    )
+
+    response = client.get("/tables")
+    assert response.status_code == 200
+    names = [item["name"] for item in response.json()]
+    assert "ready_table" in names
+
+
+def test_list_tables_hides_pending_datasets_unless_requested(client):
+    with patch("app.main._enqueue_index_job", return_value=None):
+        ingest_response = client.post(
+            "/ingest",
+            files=make_csv("name,age\nAlice,30\n"),
+            data={"dataset_name": "pending_table"},
+        )
+
+    assert ingest_response.status_code == 200
+    dataset_id = ingest_response.json()["dataset_id"]
+
+    ready_only = client.get("/tables")
+    assert ready_only.status_code == 200
+    assert all(item["dataset_id"] != dataset_id for item in ready_only.json())
+
+    include_pending = client.get("/tables?include_pending=true")
+    assert include_pending.status_code == 200
+    assert any(item["dataset_id"] == dataset_id for item in include_pending.json())
 
 
 # ── Error cases ───────────────────────────────────────────────────────────────
@@ -145,7 +180,6 @@ def test_invalid_extension(client):
     )
     assert response.status_code == 400
     assert ".csv or .tsv" in response.json()["detail"]
-
 
 def test_ingest_requires_auth():
     from fastapi.testclient import TestClient


### PR DESCRIPTION
# CPS-14


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide newly uploaded tables until their vector index is ready, preventing queries on unindexed data. Addresses CPS-14 / bug 24 with an `is_index_ready` flag and updated ingest, resume, and listing logic.

- **New Features**
  - Added `is_index_ready` column to `datasets` with a startup migration.
  - Backend `/tables` returns only indexed datasets by default; pass `include_pending=true` to see uploads in progress.
  - Set `is_index_ready` during ingest, indexing completion/failure, and resume (zero-row datasets are marked ready immediately; stale flags are corrected).
  - Retrieval summaries filter to indexed datasets only.
  - Frontend `listTables({ includePending })` option, used by `Upload` and `TableView`.
  - Tests updated to cover ready vs pending visibility.

<sup>Written for commit 7d7d153d30af007b57b5f269449398db3a661705. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



