### PR TITLE
Removed /query

### DIFF
--- a/backend/app/routes_query.py
+++ b/backend/app/routes_query.py
@@ -409,12 +409,6 @@ def _strict_lookup_error(status_code: int, message: str) -> HTTPException:
 # ── Endpoints ──────────────────────────────────────────────────────
 
 @router.post(
-    "/query",
-    response_model=QueryResponse,
-    summary="Answer natural-language semantic table queries",
-    description="Backward-compatible alias for /semantic_query.",
-)
-@router.post(
     "/semantic_query",
     response_model=QueryResponse,
     summary="Answer natural-language semantic table queries",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,7 +21,7 @@ def _ingest(client):
 
 def test_query_dataset_not_found(client):
     resp = client.post(
-        "/query",
+        "/semantic_query",
         json={"question": "Who lives in London?", "dataset_id": 9999},
     )
     assert resp.status_code == 404
@@ -29,7 +29,7 @@ def test_query_dataset_not_found(client):
 
 
 def test_query_missing_question(client):
-    resp = client.post("/query", json={"dataset_id": 1})
+    resp = client.post("/semantic_query", json={"dataset_id": 1})
     assert resp.status_code == 422
 
 
@@ -39,7 +39,7 @@ def test_query_top_k_optional(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "Who lives in London?", "dataset_id": dataset_id},
         )
 
@@ -54,7 +54,7 @@ def test_query_strict_mode_requires_dataset_id(client, monkeypatch):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "Who lives in London?"},
         )
 
@@ -72,7 +72,7 @@ def test_query_strict_mode_rejects_invalid_dataset_id(client, monkeypatch):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "Who lives in London?", "dataset_id": dataset_id + 9999},
         )
 
@@ -95,7 +95,7 @@ def test_query_auto_resolves_dataset_from_question(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "From the Chocolate table, how many entries are there?"},
         )
 
@@ -118,7 +118,7 @@ def test_query_invalid_dataset_id_resolves_from_name_hint(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "dataset_id": dataset_id + 999,
                 "question": "From the Chocolate table, what product has the most boxes shipped?",
@@ -149,7 +149,7 @@ def test_query_semantic_results(client):
     with patch("app.retrieval.search_vectors", return_value=mock_hits), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "Who lives in London?", "dataset_id": dataset_id},
         )
 
@@ -169,7 +169,7 @@ def test_query_with_filters(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "question": "tell me about this person",
                 "dataset_id": dataset_id,
@@ -202,7 +202,7 @@ def test_query_aggregate_answer_with_source_links(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "question": "What product has the most amount of boxes shipped?",
                 "dataset_id": dataset_id,
@@ -238,7 +238,7 @@ def test_query_rank_single_row_returns_name_for_who_question(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "question": "Who sold the most boxes in one deal?",
                 "dataset_id": dataset_id,
@@ -273,7 +273,7 @@ def test_query_highest_amount_in_a_day_prefers_single_row_not_grouped_total(clie
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "question": "What is the highest sales amount made in a day?",
                 "dataset_id": dataset_id,
@@ -310,7 +310,7 @@ def test_query_fail_closed_when_verification_fails(client, monkeypatch):
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]), \
          patch("app.retrieval.get_highlight", return_value=None):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "Who lives in London?", "dataset_id": dataset_id},
         )
 
@@ -336,7 +336,7 @@ def test_query_sum_with_natural_language_filter(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "question": "How many boxes shipped for Dark?",
                 "dataset_id": dataset_id,
@@ -369,7 +369,7 @@ def test_query_count_with_natural_language_filter(client):
     with patch("app.retrieval.search_vectors", return_value=[]), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={
                 "question": "How many entries are in UK?",
                 "dataset_id": dataset_id,
@@ -614,7 +614,7 @@ def test_two_pass_search_filtered_results_first(client):
     with patch("app.retrieval.search_vectors", side_effect=mock_search), \
          patch("app.retrieval.embed_texts", return_value=[[0.1] * 384]):
         resp = client.post(
-            "/query",
+            "/semantic_query",
             json={"question": "Who lives in London?", "dataset_id": dataset_id},
         )
 


### PR DESCRIPTION
Refactor to semantic_query

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the legacy `/query` endpoint and standardized on `/semantic_query` for semantic table queries. Updated tests to call `/semantic_query`.

- **Migration**
  - Replace POST `/query` with POST `/semantic_query`.
  - Request and response formats are unchanged.

<sup>Written for commit 9ac14b0fb80c84cd39aef226c1177826f96849d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

