### PR TITLE
UI changes

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -6,11 +6,11 @@ import {
   listIndexStatus,
   listTables,
   renameTable,
+  uploadTable,
   type TableIndexStatus,
   type TableSlice,
   type TableSummary,
   type UploadProgress,
-  uploadTable,
 } from "../api";
 import DataTable from "../components/DataTable";
 import logo from "../images/logo.png";
@@ -1356,8 +1356,8 @@ export default function Upload() {
             <div className="upload-icon" aria-hidden="true">
               <img src={uploadLogo} alt="" />
             </div>
-            <div className="upload-title">Select or Drag &amp; Drop Your File(s) to Start Uploading</div>
-            <div className="upload-subtitle">Supported file formats: .csv, .tsv (folders supported)</div>
+            <div className="upload-title">Select or Drag &amp; Drop Your File(s) to Upload</div>
+            <div className="upload-subtitle">Supported file formats: .csv, .tsv, folders</div>
           </label>
         ) : (
           <>


### PR DESCRIPTION
- For upload of unsupported file, it’ll just popup the same CSV/TSV upload screen with the error at the bottom
- When mcp server is down it had failed to fetch and blank boxes on the screen, just added a temp “Server is currently offline” filler screen
- Folder upload is supported now, so you can upload a folder of CSVs via drag and drop or the upload directly (tested w/ unsupported files too, it’ll upload the csv/tsv and show a warning if something isn’t uploaded)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add folder upload and clearer errors to the Upload page. Includes an offline screen when the server is unreachable.

- **New Features**
  - Folder upload via drag-and-drop or file picker (`webkitdirectory`), with recursive file collection and ignored directory placeholders.
  - Upload queue opens on drop and auto-hides when cleared.

- **Bug Fixes**
  - Unsupported file drops now show the CSV/TSV upload UI with a clear error instead of failing silently.
  - Show a “Server is currently offline” screen when requests fail or the browser is offline, preventing blank states.

<sup>Written for commit 686fdde1acf8d2f876b6e5b2a61655b5a35dd6c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

