### PR TITLE
fix create org

### DIFF
--- a/backend/app/dataset_state.py
+++ b/backend/app/dataset_state.py
@@ -126,6 +126,32 @@ def ensure_dataset_query_context_column() -> None:
         )
 
 
+def ensure_dataset_enterprise_id_column() -> None:
+    """Add datasets.enterprise_id for multi-tenant enterprises (existing DB volumes)."""
+    inspector = inspect(app_db.engine)
+    if "datasets" not in inspector.get_table_names():
+        return
+    if "enterprises" not in inspector.get_table_names():
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("datasets")}
+    if "enterprise_id" in column_names:
+        return
+
+    dialect = app_db.engine.dialect.name
+    with app_db.engine.begin() as conn:
+        if dialect == "postgresql":
+            conn.execute(
+                text(
+                    "ALTER TABLE datasets "
+                    "ADD COLUMN enterprise_id INTEGER NULL "
+                    "REFERENCES enterprises(id) ON DELETE SET NULL"
+                )
+            )
+        else:
+            conn.execute(text("ALTER TABLE datasets ADD COLUMN enterprise_id INTEGER NULL"))
+
+
 def set_dataset_index_ready(dataset_id: int, is_ready: bool) -> None:
     with app_db.SessionLocal() as db:
         db.execute(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from app.db import SessionLocal, engine
 from app.dataset_state import (
     ensure_dataset_description_column,
+    ensure_dataset_enterprise_id_column,
     ensure_dataset_query_context_column,
     ensure_dataset_columns_normalized_columns,
     ensure_dataset_index_ready_column,
@@ -62,6 +63,7 @@ async def lifespan(app: FastAPI):
     ensure_dataset_index_ready_column()
     ensure_dataset_description_column()
     ensure_dataset_query_context_column()
+    ensure_dataset_enterprise_id_column()
     try:
         from app.embeddings import get_model
         get_model()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a startup migration that creates `datasets.enterprise_id` for existing databases to fix org creation in multi-tenant setups. This prevents errors when creating enterprises on upgraded instances.

- **Bug Fixes**
  - Added `ensure_dataset_enterprise_id_column` to add a nullable `enterprise_id` to `datasets` (FK to `enterprises(id)` with ON DELETE SET NULL on PostgreSQL).
  - Called this check during app startup so existing DB volumes are migrated automatically.

<sup>Written for commit b5a973110bd6f611390ccd6c8b6d60b9dc54c6fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database initialization during application startup to support extended application infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->